### PR TITLE
chore(build): rename project to aes_cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(AES CXX)
+project(aes_cpp CXX)
 
 set(SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/aes.cpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/src/aes_utils.cpp)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# AES CPP
+# aes_cpp
 
 C++ AES(Advanced Encryption Standard) implementation
 
 Forked from [SergeyBel/AES](https://github.com/SergeyBel/AES).
 
-[![Ubuntu](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci.yml)
-[![Windows](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci-windows.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/AES/actions/workflows/aes-ci-windows.yml)
+[![Ubuntu](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci.yml)
+[![Windows](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci-windows.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci-windows.yml)
 
 Stable releases are maintained on the `stable` branch and in tagged versions.
 
@@ -141,7 +141,7 @@ These projects can be used together with aes_cpp:
 
 #Development:
 
-1. `git clone https://github.com/SergeyBel/AES.git`
+1. `git clone https://github.com/NewYaroslav/aes_cpp.git`
 1. `docker-compose up -d`
 1. use make commands
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# aes_cpp
+# aes-cpp
 
 C++ AES(Advanced Encryption Standard) implementation
 
 Forked from [SergeyBel/AES](https://github.com/SergeyBel/AES).
 
-[![Ubuntu](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci.yml)
-[![Windows](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci-windows.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci-windows.yml)
+[![Ubuntu](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci.yml)
+[![Windows](https://github.com/NewYaroslav/aes_cpp/actions/workflows/aes-ci-windows.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci-windows.yml)
 
 Stable releases are maintained on the `stable` branch and in tagged versions.
 
@@ -141,7 +141,7 @@ These projects can be used together with aes_cpp:
 
 #Development:
 
-1. `git clone https://github.com/NewYaroslav/aes_cpp.git`
+1. `git clone https://github.com/NewYaroslav/aes-cpp.git`
 1. `docker-compose up -d`
 1. use make commands
 


### PR DESCRIPTION
## Summary
- rename CMake project to `aes_cpp`
- update documentation links and instructions to new project name

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b97d67d684832cb21022ee993026c9