### PR TITLE
build: make tests optional and add library aliases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,18 @@ cmake_minimum_required(VERSION 2.8)
 
 project(aes_cpp CXX)
 
+option(AES_CPP_BUILD_TESTS "Build aes_cpp tests" ON)
+
 set(SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/aes.cpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/src/aes_utils.cpp)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-add_library(${PROJECT_NAME} ${SOURCE_FILES})
-target_include_directories(${PROJECT_NAME} PUBLIC ${INCLUDE_DIR})
+add_library(aes ${SOURCE_FILES})
+add_library(aes_cpp::aes_cpp ALIAS aes)
+add_library(aescpp ALIAS aes)
+target_include_directories(aes PUBLIC ${INCLUDE_DIR})
 
-add_executable(tests ${CMAKE_CURRENT_SOURCE_DIR}/tests/tests.cpp)
-target_link_libraries(tests ${PROJECT_NAME} gtest pthread)
+if(AES_CPP_BUILD_TESTS)
+  add_executable(tests ${CMAKE_CURRENT_SOURCE_DIR}/tests/tests.cpp)
+  target_link_libraries(tests aes gtest pthread)
+endif()

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Stable releases are maintained on the `stable` branch and in tagged versions.
 * C++ compiler
 * CMake 2.8 or newer
 
+## CMake Integration
+
+This library can be added to another CMake project via `add_subdirectory`:
+
+```cmake
+add_subdirectory(path/to/aes-cpp)
+target_link_libraries(your_app PRIVATE aes_cpp::aes_cpp)
+```
+
 ## Hardware Acceleration
 On x86 CPUs this library checks for AES-NI support at runtime and uses
 hardware-accelerated instructions when available. If AES-NI is missing, a


### PR DESCRIPTION
## Summary
- make test targets optional via `AES_CPP_BUILD_TESTS`
- add `aes_cpp::aes_cpp` and `aescpp` aliases for the main library
- document `add_subdirectory` usage in README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./tests`


------
https://chatgpt.com/codex/tasks/task_e_68b983723e44832c9147b0c253854f98