### PR TITLE
build: disable tests by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8)
 
 project(aes_cpp CXX)
 
-option(AES_CPP_BUILD_TESTS "Build aes_cpp tests" ON)
+option(AES_CPP_BUILD_TESTS "Build aes_cpp tests" OFF)
 
 set(SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/aes.cpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/src/aes_utils.cpp)

--- a/README.md
+++ b/README.md
@@ -162,7 +162,10 @@ There are four executables in `bin` folder:
 * `release` - version with optimization (main code will be taken from dev/main.cpp)  
 
 
-Build commands:  
+Build commands:
+
+Tests are disabled by default. Run CMake with `-DAES_CPP_BUILD_TESTS=ON` to build them.
+
 * `make build_all` - build all targets
 * `make build_test` - build `test` target
 * `make build_debug` - build `debug` target (defines `AESCPP_DEBUG`)


### PR DESCRIPTION
## Summary
- disable AES_CPP_BUILD_TESTS option by default
- document how to enable tests with -DAES_CPP_BUILD_TESTS=ON

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b98c118b54832ca1e51dab2157017a