### PR TITLE
Make GTest optional in vcpkg and drop OpenSSL dependency

### DIFF
--- a/.github/workflows/aes-ci.yml
+++ b/.github/workflows/aes-ci.yml
@@ -52,6 +52,22 @@ jobs:
         run: |
           make workflow_build_speed_test FLAGS="-Wall -Wextra -I./include -std=c++${{ matrix.std }}"
           ./bin/speedtest
+
+  vcpkg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          ./vcpkg/bootstrap-vcpkg.sh
+          ./vcpkg/vcpkg install --feature=tests
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake -DAES_CPP_BUILD_TESTS=ON
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build
       
       
       

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,21 @@
 cmake_minimum_required(VERSION 2.8)
 
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  if(DEFINED ENV{VCPKG_ROOT})
+    set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        CACHE STRING "" FORCE)
+  elseif(EXISTS "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
+    set(CMAKE_TOOLCHAIN_FILE
+        "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+        CACHE STRING "" FORCE)
+  else()
+    find_program(VCPKG_EXEC vcpkg)
+    if(VCPKG_EXEC)
+      execute_process(COMMAND ${VCPKG_EXEC} integrate install)
+    endif()
+  endif()
+endif()
+
 project(aes_cpp CXX)
 
 include(CMakePackageConfigHelpers)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ Stable releases are maintained on the `stable` branch and in tagged versions.
 * C++ compiler
 * CMake 2.8 or newer
 
+## Building with vcpkg
+
+```bash
+git clone https://github.com/microsoft/vcpkg.git
+./vcpkg/bootstrap-vcpkg.sh
+./vcpkg/vcpkg install
+# Enable tests with the optional feature
+./vcpkg/vcpkg install --feature=tests
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
+cmake --build build
+```
+
 ## CMake Integration
 
 This library can be added to another CMake project via `add_subdirectory`:

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "aes-cpp",
+  "version-string": "0.1.0",
+  "dependencies": [],
+  "features": {
+    "tests": {
+      "description": "Build tests",
+      "dependencies": [
+        "gtest"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- remove unused OpenSSL dependency from `vcpkg.json`
- add optional `tests` feature that pulls in GTest
- document optional tests feature in README and CI workflow

## Testing
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b99226e350832c86dcaeb89f79dbbc