### PR TITLE
Configure GTest in CMake for test builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ install(EXPORT aes_cppTargets
 )
 
 if(AES_CPP_BUILD_TESTS)
+  find_package(GTest CONFIG REQUIRED)
   add_executable(tests ${CMAKE_CURRENT_SOURCE_DIR}/tests/tests.cpp)
-  target_link_libraries(tests aes gtest pthread)
+  target_link_libraries(tests aes GTest::gtest_main pthread)
 endif()


### PR DESCRIPTION
## Summary
- integrate GTest via find_package and link tests against GTest::gtest_main

## Testing
- `cmake -S . -B build -DAES_CPP_BUILD_TESTS=ON`
- `cmake --build build`
- `./build/tests`


------
https://chatgpt.com/codex/tasks/task_e_68b99be77010832c92bf152f2d1cf91d