### PR TITLE
fix: harden padding checks

### DIFF
--- a/include/aes_cpp/aes_utils.hpp
+++ b/include/aes_cpp/aes_utils.hpp
@@ -40,10 +40,11 @@ std::vector<uint8_t> add_padding(const std::vector<uint8_t> &data);
 
 /// \brief Remove PKCS#7 padding from data.
 /// \param data Padded data.
-/// \param out Receives data with padding removed.
+/// \param out Receives data with padding bytes copied.
+/// \param out_len Receives length of data without padding.
 /// \return True if padding is valid.
-bool remove_padding(const std::vector<uint8_t> &data,
-                    std::vector<uint8_t> &out) noexcept;
+bool remove_padding(const std::vector<uint8_t> &data, std::vector<uint8_t> &out,
+                    std::size_t &out_len) noexcept;
 
 /// \brief Prepend IV to ciphertext.
 /// \param ciphertext Ciphertext without IV.

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -663,7 +663,7 @@ TEST(Utils, DecryptStringCbcInvalidPadding) {
   std::string text = "hello world";
   std::array<uint8_t, 16> key = {0};
   auto enc = aes_cpp::utils::encrypt(text, key, aes_cpp::utils::AesMode::CBC);
-  enc.ciphertext.back() ^= 0x01;
+  enc.iv.back() ^= 0x01;
   EXPECT_THROW(aes_cpp::utils::decrypt(enc, key, aes_cpp::utils::AesMode::CBC),
                std::runtime_error);
 }
@@ -674,7 +674,7 @@ TEST(Utils, DecryptStringCbcMalformedCiphertextsSameError) {
   auto enc = aes_cpp::utils::encrypt(text, key, aes_cpp::utils::AesMode::CBC);
 
   auto bad_padding = enc;
-  bad_padding.ciphertext.back() ^= 0x01;
+  bad_padding.iv.back() ^= 0x01;
 
   auto bad_length = enc;
   bad_length.ciphertext.pop_back();
@@ -706,9 +706,10 @@ TEST(Utils, RemovePaddingConstantTime) {
 
   auto measure = [](const std::vector<uint8_t> &buf) {
     std::vector<uint8_t> out;
+    std::size_t out_len;
     auto start = std::chrono::high_resolution_clock::now();
     for (int i = 0; i < 100000; ++i) {
-      aes_cpp::utils::remove_padding(buf, out);
+      aes_cpp::utils::remove_padding(buf, out, out_len);
     }
     auto end = std::chrono::high_resolution_clock::now();
     return end - start;


### PR DESCRIPTION
## Summary
- ensure CBC padding validation is deterministic and constant-time
- tweak tests to use IV tampering and new padding helper

## Testing
- `make workflow_build_test`
- `bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68b9b46c473c832c9f5501d94b7269e6