### PR TITLE
build(tests): use gtest without provided main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,5 +73,5 @@ install(EXPORT aes_cppTargets
 if(AES_CPP_BUILD_TESTS)
   find_package(GTest CONFIG REQUIRED)
   add_executable(tests ${CMAKE_CURRENT_SOURCE_DIR}/tests/tests.cpp)
-  target_link_libraries(tests aes GTest::gtest_main pthread)
+  target_link_libraries(tests aes GTest::gtest pthread)
 endif()


### PR DESCRIPTION
## Summary
- link test executable against GTest::gtest to rely on custom main

## Testing
- `cmake -S . -B build -DAES_CPP_BUILD_TESTS=ON`
- `cmake --build build`
- `./build/tests`


------
https://chatgpt.com/codex/tasks/task_e_68ba58ba8a44832cbb84b24543393940