### PR TITLE
build(cmake): register tests with ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 project(aes_cpp CXX)
+enable_testing()
 
 include(CMakePackageConfigHelpers)
 
@@ -74,4 +75,5 @@ if(AES_CPP_BUILD_TESTS)
   find_package(GTest CONFIG REQUIRED)
   add_executable(tests ${CMAKE_CURRENT_SOURCE_DIR}/tests/tests.cpp)
   target_link_libraries(tests aes GTest::gtest pthread)
+  add_test(NAME aes_cpp_tests COMMAND tests)
 endif()


### PR DESCRIPTION
## Summary
- add ctest support to the project so tests can be registered

## Testing
- `cmake -S . -B build -DAES_CPP_BUILD_TESTS=ON` *(fails: Could not find a package configuration file provided by "GTest")*
- `ctest -N --test-dir build` *(fails: Total Tests: 0)*

------
https://chatgpt.com/codex/tasks/task_e_68ba633fe6d8832c9cbdfc97126ba0cd