### PR TITLE
build: rename library target to aes_cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,17 +29,17 @@ set(SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/aes.cpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/src/aes_utils.cpp)
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-add_library(aes ${SOURCE_FILES})
-add_library(aes_cpp::aes_cpp ALIAS aes)
-add_library(aescpp ALIAS aes)
-target_include_directories(aes
+add_library(aes_cpp ${SOURCE_FILES})
+add_library(aes_cpp::aes_cpp ALIAS aes_cpp)
+add_library(aescpp ALIAS aes_cpp)
+target_include_directories(aes_cpp
   PUBLIC
     $<BUILD_INTERFACE:${INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
-set_target_properties(aes PROPERTIES EXPORT_NAME aes_cpp)
+set_target_properties(aes_cpp PROPERTIES EXPORT_NAME aes_cpp)
 
-install(TARGETS aes EXPORT aes_cppTargets
+install(TARGETS aes_cpp EXPORT aes_cppTargets
         ARCHIVE DESTINATION lib
         LIBRARY DESTINATION lib
         RUNTIME DESTINATION bin
@@ -84,6 +84,6 @@ if(AES_CPP_BUILD_TESTS)
     FetchContent_MakeAvailable(googletest)
   endif()
   add_executable(tests ${CMAKE_CURRENT_SOURCE_DIR}/tests/tests.cpp)
-  target_link_libraries(tests aes GTest::gtest pthread)
+  target_link_libraries(tests aes_cpp GTest::gtest pthread)
   add_test(NAME aes_cpp_tests COMMAND tests)
 endif()


### PR DESCRIPTION
## Summary
- rename CMake library target from `aes` to `aes_cpp`
- update aliases and install/export directives

## Testing
- `cmake -S . -B build_no_tests -D AES_CPP_BUILD_TESTS=OFF`
- `cmake --build build_no_tests --target aes_cpp`
- `cmake --install build_no_tests --prefix install`


------
https://chatgpt.com/codex/tasks/task_e_68ba6ae1e5a8832c965ad7f91e6775c4