### PR TITLE
docs: add ADVobfuscator link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ These projects can be used together with aes_cpp:
 * [hmac-cpp](https://github.com/NewYaroslav/hmac-cpp) - HMAC for authentication
 * [siphash-hpp](https://github.com/NewYaroslav/siphash-hpp) - header-only SipHash library
 * [obfy](https://github.com/NewYaroslav/obfy) - generate license verification code
+* [ADVobfuscator](https://github.com/NewYaroslav/ADVobfuscator) - compile-time C++ code obfuscation library
 * [Wiki](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard)
 * [NIST](https://www.nist.gov/publications/advanced-encryption-standard-aes)
 


### PR DESCRIPTION
## Summary
- add reference to ADVobfuscator for compile-time code obfuscation

## Testing
- `make test` *(fails: docker-compose: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba717afd48832cbf509a0ee3f5beb8