### PR TITLE
docs: document setup-hooks for pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ These projects can be used together with aes_cpp:
 # Development:
 
 1. `git clone https://github.com/NewYaroslav/aes-cpp.git`
+1. Run `./setup-hooks.sh` to enable the clang-format pre-commit hook enforced by `.clang-format`
 1. `docker-compose up -d`
 1. use make commands
 
@@ -206,5 +207,3 @@ Tests are disabled by default. Run CMake with `-DAES_CPP_BUILD_TESTS=ON` to buil
 * `make release` - run `release` version
 * `make clean` - clean `bin` directory
 
-To enable project hooks run:
-`git config core.hooksPath .githooks`


### PR DESCRIPTION
## Summary
- mention running `./setup-hooks.sh` to enable clang-format pre-commit hook

## Testing
- `make test` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_68ba73c8fb24832c81f8f3fab265eb72