### PR TITLE
build(cmake): set project version and c++11 requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   endif()
 endif()
 
-project(aes_cpp CXX)
+project(aes_cpp VERSION 0.1.0 LANGUAGES CXX)
 enable_testing()
 
 include(CMakePackageConfigHelpers)
@@ -30,6 +30,7 @@ set(SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/aes.cpp
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_library(aes_cpp ${SOURCE_FILES})
+target_compile_features(aes_cpp PUBLIC cxx_std_11)
 add_library(aes_cpp::aes_cpp ALIAS aes_cpp)
 add_library(aescpp ALIAS aes_cpp)
 target_include_directories(aes_cpp


### PR DESCRIPTION
## Summary
- declare project version and C++ language in CMake
- enforce C++11 for aes_cpp dependents

## Testing
- `pre-commit run --files CMakeLists.txt` (fails: .pre-commit-config.yaml is not a file)
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68ba7766d388832c94dac42ef3f9747c