### PR TITLE
docs: add features section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # aes-cpp
 
+- [Features](#features)
 - [Prerequisites](#prerequisites)
 - [Quick Start](#quick-start)
 - [Building with vcpkg](#building-with-vcpkg)
@@ -8,6 +9,14 @@
 - [Development](#development)
 
 C++ AES(Advanced Encryption Standard) implementation.
+
+## Features
+
+- Supports 128-, 192-, and 256-bit keys
+- Implements ECB, CBC, CFB, CTR, and GCM modes
+- Uses AES-NI hardware acceleration when available
+- Provides vector overloads for `std::vector` inputs
+- Includes debug helpers for inspecting intermediate states
 
 Forked from [SergeyBel/AES](https://github.com/SergeyBel/AES).
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # aes-cpp
 
+C++ AES(Advanced Encryption Standard) implementation.
+Forked from [SergeyBel/AES](https://github.com/SergeyBel/AES).
+
+[![Ubuntu](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci.yml)
+[![Windows](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci-windows.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci-windows.yml)
+
+Stable releases are maintained on the `stable` branch and in tagged versions.
+
 - [Features](#features)
 - [Prerequisites](#prerequisites)
 - [Quick Start](#quick-start)
@@ -7,8 +15,6 @@
 - [CMake Integration](#cmake-integration)
 - [Usage](#usage)
 - [Development](#development)
-
-C++ AES(Advanced Encryption Standard) implementation.
 
 ## Features
 
@@ -18,14 +24,8 @@ C++ AES(Advanced Encryption Standard) implementation.
 - Provides vector overloads for `std::vector` inputs
 - Includes debug helpers for inspecting intermediate states
 
-Forked from [SergeyBel/AES](https://github.com/SergeyBel/AES).
-
-[![Ubuntu](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci.yml)
-[![Windows](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci-windows.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci-windows.yml)
-
-Stable releases are maintained on the `stable` branch and in tagged versions.
-
 ## Prerequisites
+
 * C++11 or newer compiler
 * CMake 3.14 or newer
 
@@ -94,20 +94,24 @@ target_link_libraries(your_app PRIVATE aes_cpp::aes_cpp)
 ```
 
 ## Hardware Acceleration
+
 On x86 CPUs this library checks for AES-NI support at runtime and uses
 hardware-accelerated instructions when available. If AES-NI is missing, a
 portable software implementation is used instead.
 
 ## Supported Modes
+
 ECB, CBC, CFB, CTR and GCM modes are implemented. GCM additionally produces an authentication tag for message integrity. CBC, CFB and CTR can be paired with a MAC callback (e.g., HMAC) to authenticate `IV || ciphertext`; omitting the callback leaves them vulnerable to tampering.
 ECB mode is provided for completeness but leaks plaintext patterns and should be avoided. Prefer authenticated encryption modes such as GCM that provide both confidentiality and integrity.
 
 ## IV Generation
+
 `aes_cpp::utils` provides helpers for creating random IVs. `generate_iv_16()`
 produces a 16-byte IV for CBC, CFB and CTR modes, while `generate_iv_12()`
 returns a 12-byte IV recommended for GCM.
 
 ## Vector Overloads
+
 All encryption and decryption methods have overloads that accept `std::vector<unsigned char>` in addition to raw pointer APIs:
 ```c++
 #include <aes_cpp/aes.hpp>
@@ -121,6 +125,7 @@ auto cipherVec = aesVec.EncryptCBC(plainVec, keyVec, iv);
 ```
 
 ## Clearing Cached Keys
+
 The `AES` class caches the last key and its expanded round keys for reuse.
 Call `clear_cache()` when this material is no longer needed to securely erase
 it. The destructor invokes this automatically.
@@ -132,6 +137,7 @@ Defining the `AESCPP_DEBUG` macro enables helper functions such as `printHexArra
 ## Usage
 
 ### Encryption/Decryption
+
 ```c++
 #include <aes_cpp/aes.hpp>
 
@@ -145,6 +151,7 @@ auto restored = aes.DecryptCBC(cipher.get(), sizeof(plain), key, iv);
 ```
 
 ### encrypt/decrypt with `AesMode::CTR`
+
 ```c++
 #include <aes_cpp/aes_utils.hpp>
 
@@ -159,6 +166,7 @@ auto restored =
 ```
 
 ### MAC Callback
+
 `utils::encrypt`, `utils::decrypt`, and `utils::decrypt_to_string` for CBC, CFB
 and CTR modes accept an optional callback for computing a message
 authentication code. The library authenticates the concatenation of IV and
@@ -178,11 +186,13 @@ auto restored =
 ```
 
 ### Constant-Time Comparison
+
 `utils::constant_time_equal` compares byte vectors without leaking
 information through timing, but it assumes the lengths of both inputs are
 public because it checks them and derives a loop bound from the larger size.
 
 ### GCM Helpers
+
 `encrypt_gcm` and `decrypt_gcm` manage the 12-byte IV, optional additional
 authenticated data (AAD), and the authentication tag produced by GCM.
 


### PR DESCRIPTION
## Summary
- document library features including key sizes, modes, AES-NI, vector overloads, and debug helpers
- clarify key-length wording in features list

## Testing
- `./setup-hooks.sh`
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"` *(fails: gtest/gtest.h missing)*
- `./bin/test` *(fails: No such file or directory)*
- `apt-get install -y libgtest-dev` *(fails: package not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ba80ae3854832cbd03f6812067f0b8