### PR TITLE
docs(readme): add license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Forked from [SergeyBel/AES](https://github.com/SergeyBel/AES).
 
 [![Ubuntu](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci.yml)
 [![Windows](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci-windows.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/aes-cpp/actions/workflows/aes-ci-windows.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Stable releases are maintained on the `stable` branch and in tagged versions.
 
@@ -286,5 +287,10 @@ cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=.\vcpkg\scripts\buildsystems\vcpkg.cm
 cmake --build build --config Release
 ctest --test-dir build -C Release
 ```
+
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
 
 


### PR DESCRIPTION
## Summary
- add MIT license badge to top of README
- include License section referencing MIT license

## Testing
- `./setup-hooks.sh`
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"` *(fails: gtest/gtest.h: No such file or directory)*
- `./bin/test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba80b2bde0832caea943fcf49b7a70