### PR TITLE
build: add GoogleTest install helper and safe clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,11 @@ style_fix:
 
 
 clean:
-	docker-compose exec aes rm -rf bin/*
+	@if command -v docker-compose >/dev/null 2>&1; then \
+		docker-compose exec aes rm -rf bin/*; \
+	else \
+		rm -rf bin/*; \
+	fi
 
 
 workflow_build_test: ; g++ $(FLAGS) $(CXXFLAGS) -c ./src/aes.cpp -o bin/aes.o; g++ $(FLAGS) $(CXXFLAGS) -c ./src/aes_utils.cpp -o bin/aes_utils.o; g++ $(FLAGS) $(CXXFLAGS) $(TEST_FLAGS) -g bin/aes.o bin/aes_utils.o ./tests/tests.cpp $(GTEST_LIBS) -o bin/test

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ These projects can be used together with aes_cpp:
 
 1. `git clone https://github.com/NewYaroslav/aes-cpp.git`
 1. Run `./setup-hooks.sh` to enable the clang-format pre-commit hook enforced by `.clang-format`
+1. Run `./dev/install_gtest.sh` to install GoogleTest for local builds
 1. `docker-compose up -d`
 1. use make commands
 

--- a/dev/install_gtest.sh
+++ b/dev/install_gtest.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install GoogleTest and build static libraries for linking
+if ! command -v g++ >/dev/null; then
+  echo "g++ is required" >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y libgtest-dev cmake
+
+cd /usr/src/gtest
+sudo cmake .
+sudo make
+sudo cp lib/*.a /usr/lib/


### PR DESCRIPTION
## Summary
- add script to install GoogleTest and document its usage in development guide
- allow `make clean` to work without docker-compose

## Testing
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8030ed20832c84d58af06f4aba71