### PR TITLE
fix(speedtest): handle random generation failure

### DIFF
--- a/speedtest/main.cpp
+++ b/speedtest/main.cpp
@@ -3,6 +3,7 @@
 #include <aes_cpp/aes.hpp>
 #include <aes_cpp/aes_utils.hpp>
 #include <iostream>
+#include <stdexcept>
 
 const unsigned int MICROSECONDS = 1000000;
 unsigned long getMicroseconds() {
@@ -14,7 +15,10 @@ unsigned long getMicroseconds() {
 // Generate plaintext filled with cryptographically secure random bytes.
 unsigned char *getRandomPlain(unsigned int length) {
   unsigned char *plain = new unsigned char[length];
-  aes_cpp::utils::detail::fill_os_random(plain, length);
+  if (!aes_cpp::utils::detail::fill_os_random(plain, length)) {
+    delete[] plain;
+    throw std::runtime_error("Failed to generate random bytes");
+  }
   return plain;
 }
 


### PR DESCRIPTION
## Summary
- check `fill_os_random` result in `getRandomPlain`
- free memory and throw on random generation failure

## Testing
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"`
- `./bin/test`

------
https://chatgpt.com/codex/tasks/task_e_68ba991a1608832c966427f7e25c268e