### PR TITLE
docs: add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Style
+- Format all C and C++ sources with `clang-format`.
+- Run `./setup-hooks.sh` to install the pre-commit hook.
+
+## Tests
+- Build and run tests with `make workflow_build_test`.
+- Execute `./bin/test` to ensure all tests pass.
+
+## Pull Requests
+- Create a new branch for your change.
+- Run formatting and tests before pushing.
+- Follow commit message rules in [AGENTS.md](AGENTS.md).
+- Open the pull request targeting `main`.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md with style, testing, and PR instructions

## Testing
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"` (fails: gtest/gtest.h: No such file or directory)
- `./bin/test` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68baa5a7ecbc832cbe31c1a21313407e