### PR TITLE
docs: add AES mode examples and README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,27 +43,11 @@ cmake -S . -B build -DAES_CPP_BUILD_TESTS=ON
 cmake --build build
 ctest --test-dir build
 ```
-
-```c++
-#include <aes_cpp/aes_utils.hpp>
-#include <array>
-#include <string>
-#include <iostream>
-
-int main() {
-    using namespace aes_cpp;
-    std::string text = "Hello AES";
-    std::array<uint8_t, 16> key = {0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,
-                                   0x08,0x09,0x0a,0x0b,0x0c,0x0d,0x0e,0x0f};
-    auto encrypted = utils::encrypt(text, key, utils::AesMode::CTR);
-    auto decrypted = utils::decrypt_to_string(encrypted, key, utils::AesMode::CTR);
-    std::cout << decrypted << std::endl;
-}
-```
+See [examples/ctr.cpp](examples/ctr.cpp) for a minimal usage example.
 
 ```bash
-g++ quickstart.cpp -std=c++17 -Iinclude build/libaes_cpp.a -o quickstart
-./quickstart
+g++ examples/ctr.cpp -std=c++17 -Iinclude build/libaes_cpp.a -o ctr_example
+./ctr_example
 ```
 
 ## Building with vcpkg
@@ -109,6 +93,16 @@ portable software implementation is used instead.
 
 ECB, CBC, CFB, CTR and GCM modes are implemented. GCM additionally produces an authentication tag for message integrity. CBC, CFB and CTR can be paired with a MAC callback (e.g., HMAC) to authenticate `IV || ciphertext`; omitting the callback leaves them vulnerable to tampering.
 ECB mode is provided for completeness but leaks plaintext patterns and should be avoided. Prefer authenticated encryption modes such as GCM that provide both confidentiality and integrity.
+
+## Examples
+
+| Mode | Example |
+| ---- | ------- |
+| ECB  | [examples/ecb.cpp](examples/ecb.cpp) |
+| CBC  | [examples/cbc.cpp](examples/cbc.cpp) |
+| CFB  | [examples/cfb.cpp](examples/cfb.cpp) |
+| CTR  | [examples/ctr.cpp](examples/ctr.cpp) |
+| GCM  | [examples/gcm.cpp](examples/gcm.cpp) |
 
 ## IV Generation
 
@@ -204,20 +198,8 @@ authenticated data (AAD), and the authentication tag produced by GCM.
 
 GCM limits AAD to `(1ULL << 39) - 256` bytes and the combined length of AAD and
 plaintext to the same bound. The library throws `std::length_error` if these
-limits are exceeded:
-```c++
-#include <aes_cpp/aes_utils.hpp>
-
-using namespace aes_cpp;
-
-std::string text = "GCM example";
-std::array<uint8_t, 16> key = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-                                0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
-std::vector<uint8_t> aad = { 'h', 'e', 'a', 'd', 'e', 'r' };
-auto data = utils::encrypt_gcm(text, key, aad);
-// data.tag holds the 16-byte authentication tag
-auto plain = utils::decrypt_gcm_to_string(data, key, aad);
-```
+limits are exceeded. See [examples/gcm.cpp](examples/gcm.cpp) for a complete
+example.
 
 # Padding
 
@@ -234,18 +216,7 @@ aes_cpp::utils::remove_padding(decrypted, out);
 ```
 
 Higher-level helpers apply this padding automatically:
-
-```c++
-#include <aes_cpp/aes_utils.hpp>
-
-using namespace aes_cpp;
-
-std::string text = "CBC example";
-std::array<uint8_t, 16> key = { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-                                0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f };
-auto encrypted = utils::encrypt(text, key, utils::AesMode::CBC);
-auto restored = utils::decrypt_to_string(encrypted, key, utils::AesMode::CBC);
-```
+See [examples/cbc.cpp](examples/cbc.cpp) for a complete CBC example.
 
 CFB, CTR and GCM modes operate on data of any length.
 

--- a/examples/cbc.cpp
+++ b/examples/cbc.cpp
@@ -1,0 +1,17 @@
+#include <aes_cpp/aes_utils.hpp>
+#include <array>
+#include <iostream>
+#include <string>
+
+int main() {
+  using namespace aes_cpp;
+  std::string text = "CBC example";
+  std::array<uint8_t, 16> key = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                                 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                                 0x0c, 0x0d, 0x0e, 0x0f};
+  auto encrypted = utils::encrypt(text, key, utils::AesMode::CBC);
+  auto decrypted =
+      utils::decrypt_to_string(encrypted, key, utils::AesMode::CBC);
+  std::cout << decrypted << std::endl;
+  return 0;
+}

--- a/examples/cfb.cpp
+++ b/examples/cfb.cpp
@@ -1,0 +1,17 @@
+#include <aes_cpp/aes_utils.hpp>
+#include <array>
+#include <iostream>
+#include <string>
+
+int main() {
+  using namespace aes_cpp;
+  std::string text = "CFB example";
+  std::array<uint8_t, 16> key = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                                 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                                 0x0c, 0x0d, 0x0e, 0x0f};
+  auto encrypted = utils::encrypt(text, key, utils::AesMode::CFB);
+  auto decrypted =
+      utils::decrypt_to_string(encrypted, key, utils::AesMode::CFB);
+  std::cout << decrypted << std::endl;
+  return 0;
+}

--- a/examples/ctr.cpp
+++ b/examples/ctr.cpp
@@ -1,0 +1,17 @@
+#include <aes_cpp/aes_utils.hpp>
+#include <array>
+#include <iostream>
+#include <string>
+
+int main() {
+  using namespace aes_cpp;
+  std::string text = "CTR example";
+  std::array<uint8_t, 16> key = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                                 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                                 0x0c, 0x0d, 0x0e, 0x0f};
+  auto encrypted = utils::encrypt(text, key, utils::AesMode::CTR);
+  auto decrypted =
+      utils::decrypt_to_string(encrypted, key, utils::AesMode::CTR);
+  std::cout << decrypted << std::endl;
+  return 0;
+}

--- a/examples/ecb.cpp
+++ b/examples/ecb.cpp
@@ -1,0 +1,17 @@
+#include <aes_cpp/aes_utils.hpp>
+#include <array>
+#include <iostream>
+#include <string>
+
+int main() {
+  using namespace aes_cpp;
+  std::string text = "0123456789ABCDEF";  // 16 bytes for ECB
+  std::array<uint8_t, 16> key = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                                 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                                 0x0c, 0x0d, 0x0e, 0x0f};
+  auto encrypted = utils::encrypt(text, key, utils::AesMode::ECB);
+  auto decrypted =
+      utils::decrypt_to_string(encrypted, key, utils::AesMode::ECB);
+  std::cout << decrypted << std::endl;
+  return 0;
+}

--- a/examples/gcm.cpp
+++ b/examples/gcm.cpp
@@ -1,0 +1,18 @@
+#include <aes_cpp/aes_utils.hpp>
+#include <array>
+#include <iostream>
+#include <string>
+#include <vector>
+
+int main() {
+  using namespace aes_cpp;
+  std::string text = "GCM example";
+  std::array<uint8_t, 16> key = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
+                                 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+                                 0x0c, 0x0d, 0x0e, 0x0f};
+  std::vector<uint8_t> aad = {'h', 'e', 'a', 'd', 'e', 'r'};
+  auto data = utils::encrypt_gcm(text, key, aad);
+  auto plain = utils::decrypt_gcm_to_string(data, key, aad);
+  std::cout << plain << std::endl;
+  return 0;
+}


### PR DESCRIPTION
## Summary
- group example code by AES mode in new `examples/`
- reference each mode from a README table

## Testing
- `./setup-hooks.sh`
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"` *(fails: gtest/gtest.h not found)*
- `./bin/test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68baa598a938832c80f8407ba2273ff0