### PR TITLE
docs: include setup-hooks in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Stable releases are maintained on the `stable` branch and in tagged versions.
 ```bash
 git clone https://github.com/NewYaroslav/aes-cpp.git
 cd aes-cpp
+./setup-hooks.sh # Activate clang-format pre-commit hook required by CI
 cmake -S . -B build
 cmake --build build
 
@@ -43,6 +44,8 @@ cmake -S . -B build -DAES_CPP_BUILD_TESTS=ON
 cmake --build build
 ctest --test-dir build
 ```
+
+`./setup-hooks.sh` enables the clang-format pre-commit check enforced by the CI pipeline.
 
 ```c++
 #include <aes_cpp/aes_utils.hpp>


### PR DESCRIPTION
## Summary
- add `./setup-hooks.sh` step to Quick Start
- note that script enables clang-format pre-commit check required by CI

## Testing
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"` *(fails: gtest/gtest.h: No such file or directory)*
- `./bin/test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68baa56ebc44832cb6e857db52572908