### PR TITLE
feat(build): add AES-NI flag option and clarify acceleration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ include(CMakePackageConfigHelpers)
 set(AES_CPP_VERSION 0.1.0)
 
 option(AES_CPP_BUILD_TESTS "Build aes_cpp tests" OFF)
+option(AES_CPP_ENABLE_AESNI "Build AES-NI/PCLMUL code paths" ON)
 
 set(SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/aes.cpp
                  ${CMAKE_CURRENT_SOURCE_DIR}/src/aes_utils.cpp)
@@ -39,6 +40,12 @@ target_include_directories(aes_cpp
     $<INSTALL_INTERFACE:include>
 )
 set_target_properties(aes_cpp PROPERTIES EXPORT_NAME aes_cpp)
+
+if(AES_CPP_ENABLE_AESNI
+   AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang"
+   AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|i.86")
+  target_compile_options(aes_cpp PRIVATE -maes -mpclmul -msse2 -mssse3)
+endif()
 
 install(TARGETS aes_cpp EXPORT aes_cppTargets
         ARCHIVE DESTINATION lib

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ Forked from [SergeyBel/AES](https://github.com/SergeyBel/AES) and extended with 
 
 * AES-128 / AES-192 / AES-256
 * Modes: **ECB**, **CBC**, **CFB**, **CTR**, **GCM**
-* Runtime AES-NI detection on x86/x86\_64; software fallback otherwise
+* Runtime AES-NI detection on x86/x86\_64 when built with AES-NI/PCLMUL flags;
+  software fallback otherwise
 * Convenience utilities (`aes_cpp::utils`) with string/`std::vector` helpers
 * Optional debug helpers (hex printers) behind `AESCPP_DEBUG`
 * CMake package: `aes_cpp::aes_cpp` target, `find_package` support
@@ -274,7 +275,8 @@ PKCS#7 helpers and higher-level CBC helpers that apply padding automatically.
 ## Vector Overloads
 
 Most APIs provide `std::vector<uint8_t>` overloads. They do **not** copy the input;
-they allocate an output vector and write results directly into it (return uses NRVO/move).
+they allocate a new output vector and write results directly into it (return uses
+NRVO/move).
 For zero-allocation scenarios, use pointer/size APIs with a caller-provided output buffer,
 or in-place pointer APIs (same buffer for input/output) where applicable.
 Note: `DecryptGCM` normalizes the tag to 16 bytes (may copy/resize the tag).
@@ -286,12 +288,16 @@ A span-like API may be added later.
 
 ## Hardware Acceleration
 
-* **x86/x86_64**: runtime AES-NI detection; hardware path when available, otherwise software fallback.
+* **x86/x86_64**: runtime AES-NI detection when compiled with AES-NI/PCLMUL
+  support; hardware path when available, otherwise software fallback.
 * **GHASH** (GCM) uses PCLMULQDQ with SSSE3 shuffles when available.
 * **Non-x86 (e.g., ARMv8)**: currently uses software path (no ARM Crypto Extensions yet).
 
 ### Build flags for acceleration
-* GCC/Clang: pass `-maes -mpclmul -mssse3` to compile AES-NI/PCLMUL code paths (selected at runtime).
+* CMake option: `AES_CPP_ENABLE_AESNI` (default **ON**) adds the necessary
+  compiler flags on GCC/Clang x86 targets.
+* GCC/Clang: pass `-maes -mpclmul -msse2 -mssse3` to compile AES-NI/PCLMUL code
+  paths (selected at runtime).
 * MSVC: intrinsics available by default; CPUID selects the path at runtime.
 * Without these flags, the software path is always used.
 

--- a/include/aes_cpp/aes.hpp
+++ b/include/aes_cpp/aes.hpp
@@ -7,14 +7,16 @@
 #include <cstring>
 #include <iostream>
 #include <memory>
-#include <mutex>
 #if __cplusplus >= 201703L
 #include <shared_mutex>
-#define AESCPP_SHARED_MUTEX std::shared_mutex
-#define AESCPP_SHARED_LOCK std::shared_lock
+using AESCPP_SHARED_MUTEX = std::shared_mutex;
+template <class M>
+using AESCPP_SHARED_LOCK = std::shared_lock<M>;
 #else
-#define AESCPP_SHARED_MUTEX std::mutex
-#define AESCPP_SHARED_LOCK std::unique_lock
+#include <mutex>
+using AESCPP_SHARED_MUTEX = std::mutex;
+template <class M>
+using AESCPP_SHARED_LOCK = std::unique_lock<M>;
 #endif
 #include <stdexcept>
 #include <string>

--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -4,8 +4,8 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <stdexcept>
-#include <string>
 
 #if defined(__has_include)
 #if __has_include(<strings.h>)
@@ -40,8 +40,8 @@ namespace aes_cpp {
 void secure_zero(void *p, size_t n) {
 #if defined(_WIN32)
   SecureZeroMemory(p, n);
-#elif defined(explicit_bzero) || defined(__GLIBC__) || defined(__APPLE__) || \
-    defined(__OpenBSD__) || defined(__FreeBSD__)
+#elif defined(__GLIBC__) || defined(__APPLE__) || defined(__OpenBSD__) || \
+    defined(__FreeBSD__)
   explicit_bzero(p, n);
 #elif defined(__STDC_LIB_EXT1__)
   memset_s(p, n, 0, n);


### PR DESCRIPTION
## Summary
- add optional AES-NI/PCLMUL compile flags for GCC/Clang x86
- document hardware acceleration flags and vector behavior
- clean up secure zero and shared mutex helpers

## Testing
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0ad32950832cb2dcb8f5948b2442