### PR TITLE
fix(aes): enable MSVC hardware acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ int main() {
 }
 ```
 
-**Note (CTR):** throws `std::length_error` on 128-bit counter wrap-around (practically unreachable).
+**Note (CTR):** increments the 128-bit counter in big-endian order (`J0+1`, `J0+2`, ...); throws `std::length_error` on counter wrap-around (practically unreachable).
 
 ### GCM example (AEAD) + serialization
 


### PR DESCRIPTION
## Summary
- compile AES-NI and PCLMUL paths under MSVC x86/x64
- clarify constant-time equality contract and big-endian CTR counter

## Testing
- `bash dev/gf_multiply_branch_check.sh`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68bb11edb6dc832c9662543fa90d5d93