### PR TITLE
fix(gcm): enforce byte-based AAD limits

### DIFF
--- a/src/aes.cpp
+++ b/src/aes.cpp
@@ -491,9 +491,9 @@ void AES::EncryptGCM(const unsigned char in[], size_t inLen,
   if (!iv || (!aad && aadLen > 0) || !tag)
     throw std::invalid_argument("Null IV, AAD or tag");
   if (inLen > (1ULL << 32) * 16) throw std::length_error("Input too long");
-  const uint64_t gcmLimit = (1ULL << 39) - 256;
-  if (aadLen > gcmLimit) throw std::length_error("AAD too long");
-  if (aadLen + inLen > gcmLimit)
+  const uint64_t gcmByteLimit = ((1ULL << 39) - 256) / 8;
+  if (aadLen > gcmByteLimit) throw std::length_error("AAD too long");
+  if (aadLen + inLen > gcmByteLimit)
     throw std::length_error("AAD + input too long");
   auto roundKeys = prepare_round_keys(key);
 
@@ -570,9 +570,9 @@ void AES::DecryptGCM(const unsigned char in[], size_t inLen,
   if (!iv || (!aad && aadLen > 0) || !tag)
     throw std::invalid_argument("Null IV, AAD or tag");
   if (inLen > (1ULL << 32) * 16) throw std::length_error("Input too long");
-  const uint64_t gcmLimit = (1ULL << 39) - 256;
-  if (aadLen > gcmLimit) throw std::length_error("AAD too long");
-  if (aadLen + inLen > gcmLimit)
+  const uint64_t gcmByteLimit = ((1ULL << 39) - 256) / 8;
+  if (aadLen > gcmByteLimit) throw std::length_error("AAD too long");
+  if (aadLen + inLen > gcmByteLimit)
     throw std::length_error("AAD + input too long");
   auto roundKeys = prepare_round_keys(key);
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -650,6 +650,44 @@ TEST(GCM, InputTooLong) {
                std::length_error);
 }
 
+TEST(GCM, AadTooLong) {
+  aes_cpp::AES aes(aes_cpp::AESKeyLength::AES_128);
+  unsigned char in = 0;
+  unsigned char out;
+  unsigned char aad = 0;
+  std::array<unsigned char, 16> key{};
+  std::array<unsigned char, 12> iv{};
+  std::array<unsigned char, 16> tag{};
+  const size_t gcmByteLimit = ((1ULL << 39) - 256) / 8;
+
+  EXPECT_THROW(aes.EncryptGCM(&in, 0, key.data(), iv.data(), &aad,
+                              gcmByteLimit + 1, tag.data(), &out),
+               std::length_error);
+
+  EXPECT_THROW(aes.DecryptGCM(&in, 0, key.data(), iv.data(), &aad,
+                              gcmByteLimit + 1, tag.data(), &out),
+               std::length_error);
+}
+
+TEST(GCM, AadPlusInputTooLong) {
+  aes_cpp::AES aes(aes_cpp::AESKeyLength::AES_128);
+  unsigned char in = 0;
+  unsigned char out;
+  unsigned char aad = 0;
+  std::array<unsigned char, 16> key{};
+  std::array<unsigned char, 12> iv{};
+  std::array<unsigned char, 16> tag{};
+  const size_t gcmByteLimit = ((1ULL << 39) - 256) / 8;
+
+  EXPECT_THROW(aes.EncryptGCM(&in, 1, key.data(), iv.data(), &aad, gcmByteLimit,
+                              tag.data(), &out),
+               std::length_error);
+
+  EXPECT_THROW(aes.DecryptGCM(&in, 1, key.data(), iv.data(), &aad, gcmByteLimit,
+                              tag.data(), &out),
+               std::length_error);
+}
+
 TEST(Utils, EncryptDecryptStringCBC) {
   std::string text = "hello world";
   std::array<uint8_t, 16> key = {0};


### PR DESCRIPTION
## Summary
- enforce GCM AAD length checks using byte limits
- add regression tests for GCM AAD length boundaries

## Testing
- `bash dev/gf_multiply_branch_check.sh && echo GF_Multiply_OK`
- `make workflow_build_test FLAGS="-Wall -Wextra -I./include -std=c++17" TEST_FLAGS="-Wall -Wextra -I./include -std=c++17"`
- `./bin/test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1d54f6bc832c97ea410a6be6e097